### PR TITLE
Check retro-wordle-bot access

### DIFF
--- a/server/services/retro-achievements.ts
+++ b/server/services/retro-achievements.ts
@@ -71,19 +71,19 @@ class RetroAchievementsService {
 
       console.log(`Fetching achievement ${achievementId} from RetroAchievements API...`);
       
-      const response = await axios.get(`${this.baseUrl}/API_GetAchievementInfo.php`, {
+      const response = await axios.get(`${this.baseUrl}/API_GetAchievementUnlocks.php`, {
         params: {
           ...this.getAuthParams(),
-          i: achievementId
+          a: achievementId
         },
         timeout: 10000
       });
 
       console.log('RetroAchievements API response:', JSON.stringify(response.data, null, 2));
 
-      // The API_GetAchievementInfo.php returns the achievement data directly
-      if (response.data && response.data.ID) {
-        const achievement = response.data;
+      // The API_GetAchievementUnlocks.php returns the achievement data in the Achievement field
+      if (response.data && response.data.Achievement && response.data.Achievement.ID) {
+        const achievement = response.data.Achievement;
         return {
           id: achievement.ID.toString(),
           title: achievement.Title,
@@ -138,16 +138,16 @@ class RetroAchievementsService {
 
       console.log('Achievement unlocks response:', JSON.stringify(response.data, null, 2));
 
-      if (response.data && response.data.RecentWinners) {
-        const recentWinners = response.data.RecentWinners || [];
+      if (response.data && response.data.Unlocks) {
+        const unlocks = response.data.Unlocks || [];
         
-        console.log(`Checking ${recentWinners.length} recent winners for user ${username} on ${targetDate}`);
+        console.log(`Checking ${unlocks.length} unlocks for user ${username} on ${targetDate}`);
         
         // Check if the user earned this achievement on the target date
-        const userUnlock = recentWinners.find((winner: any) => {
-          const matchesUser = winner.User === username;
-          const matchesDate = winner.DateEarned?.startsWith(targetDate);
-          console.log(`Winner: ${winner.User}, Date: ${winner.DateEarned}, Matches User: ${matchesUser}, Matches Date: ${matchesDate}`);
+        const userUnlock = unlocks.find((unlock: any) => {
+          const matchesUser = unlock.User === username;
+          const matchesDate = unlock.DateAwarded?.startsWith(targetDate);
+          console.log(`Unlock: ${unlock.User}, Date: ${unlock.DateAwarded}, Matches User: ${matchesUser}, Matches Date: ${matchesDate}`);
           return matchesUser && matchesDate;
         });
         
@@ -156,7 +156,7 @@ class RetroAchievementsService {
         return result;
       }
 
-      console.log('No RecentWinners found in response');
+      console.log('No Unlocks found in response');
       return false;
     } catch (error) {
       console.error('Error checking user achievement unlock date:', error);


### PR DESCRIPTION
Fix RetroAchievements API integration by updating the endpoint and data parsing to resolve 404 errors.

The original implementation used `API_GetAchievementInfo.php` which was returning 404s. Investigation revealed that `API_GetAchievementUnlocks.php` with parameter `a` is the correct endpoint for fetching achievement details and unlock information, and the response structure for unlocks was also different (`Unlocks` instead of `RecentWinners`).

---
<a href="https://cursor.com/background-agent?bcId=bc-a4199aa4-b038-490c-b7bb-4082c0a805b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a4199aa4-b038-490c-b7bb-4082c0a805b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>